### PR TITLE
add time based revalidation fallback

### DIFF
--- a/.github/workflows/deploy-expirator-service.yml
+++ b/.github/workflows/deploy-expirator-service.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'next-enterprise/expirator-service/**'
+      - "next-enterprise/expirator-service/**"
 
 concurrency:
   group: ${{ github.workflow }}

--- a/next-14/src/app/ThemeButton.tsx
+++ b/next-14/src/app/ThemeButton.tsx
@@ -8,7 +8,16 @@ export function ThemeButton() {
   return (
     <button
       disabled={pending}
-      onClick={() => startTransition(() => randomColorTheme())}
+      onClick={() =>
+        startTransition(() =>
+          randomColorTheme().then((data) => {
+            if (data?.background && data?.text) {
+              document.documentElement.style.setProperty('--theme-background', data.background)
+              document.documentElement.style.setProperty('--theme-text', data.text)
+            }
+          }),
+        )
+      }
       className={`bg-theme-button text-theme-button focus:ring-theme focus:ring-offset-theme focus:outline-hidden cursor-pointer rounded-md px-4 py-2 text-sm font-semibold transition ease-in-out focus:ring-2 focus:ring-opacity-50 focus:ring-offset-2 focus:duration-0 disabled:cursor-not-allowed disabled:opacity-50 ${pending ? 'animate-pulse cursor-wait duration-150' : 'duration-1000'} `}
     >
       {pending ? 'Generating...' : 'Random Color Theme'}

--- a/next-14/src/app/actions.ts
+++ b/next-14/src/app/actions.ts
@@ -4,7 +4,6 @@ import type {SyncTag} from '@sanity/client'
 import {revalidateTag} from 'next/cache'
 
 export async function expireTags(tags: SyncTag[]) {
-  revalidateTag('sanity:fetch-sync-tags')
   for (const tag of tags) {
     revalidateTag(tag)
   }
@@ -12,8 +11,15 @@ export async function expireTags(tags: SyncTag[]) {
 }
 
 export async function randomColorTheme() {
-  await fetch('https://lcapi-examples-api.sanity.dev/api/random-color-theme', {
+  const response = await fetch('https://lcapi-examples-api.sanity.dev/api/random-color-theme', {
     method: 'PUT',
   })
-  revalidateTag('theme')
+  if (!response.ok) {
+    return null
+  }
+  const data = await response.json()
+  if (typeof data === 'object' && 'background' in data && 'text' in data) {
+    return data as {background: string; text: string}
+  }
+  return null
 }

--- a/next-14/src/app/layout.tsx
+++ b/next-14/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const {data} = await sanityFetch({query: THEME_QUERY, tags: ['theme']})
+  const {data} = await sanityFetch({query: THEME_QUERY})
 
   return (
     <html

--- a/next-14/src/sanity/client.ts
+++ b/next-14/src/sanity/client.ts
@@ -3,6 +3,6 @@ import {createClient} from '@sanity/client'
 export const client = createClient({
   projectId: 'hiomol4a',
   dataset: 'lcapi',
-  apiVersion: '2024-09-22',
+  apiVersion: '2025-02-19',
   useCdn: true,
 })

--- a/next-14/src/sanity/fetch.ts
+++ b/next-14/src/sanity/fetch.ts
@@ -7,28 +7,32 @@ import {client} from './client'
  * The `defineLive` utility in `next-sanity` handles more advanced use cases, such as live preview, integrating with `sanity/presentation`, and more.
  * @example
  * import {createClient, defineLive} from 'next-sanity'
- * export const {sanityFetch, SanityLive} = defineLive({client: createClient({projectId, dataset, ...})})
+ * export const {sanityFetch, SanityLive} = defineLive({
+ *   client: createClient({projectId, dataset, ...}),
+ *   fetchOptions: {
+ *     revalidate: 15 * 60
+ *   }
+ * })
  */
 export async function sanityFetch<const QueryString extends string>({
   query,
   params = {},
-  tags = [],
 }: {
   query: QueryString
   params?: QueryParams
-  tags?: string[]
-}): Promise<{data: ClientReturn<QueryString, unknown>; tags: string[]}> {
+}): Promise<{data: ClientReturn<QueryString, unknown>; tags?: string[]}> {
   // We have to fetch the sync tags first (this double-fetching is required until the new `cacheTag` API, related to 'use cache', is available in a stable next.js release)
   const {syncTags} = await client.fetch(query, params, {
     filterResponse: false,
     cacheMode: 'noStale',
     tag: 'fetch-sync-tags', // The request tag makes the fetch unique, avoids deduping with the cached query that has tags
-    next: {revalidate: false, tags: ['sanity:fetch-sync-tags', ...tags]},
+    cache: 'force-cache',
+    next: {revalidate: 15 * 60},
   })
-  const cacheTags = [...(syncTags || []), ...tags]
   const data = await client.fetch(query, params, {
     cacheMode: 'noStale',
-    next: {revalidate: false, tags: cacheTags},
+    cache: 'force-cache',
+    next: {revalidate: 15 * 60, tags: syncTags},
   })
-  return {data, tags: cacheTags}
+  return {data, tags: syncTags}
 }

--- a/next-14/src/sanity/fetch.ts
+++ b/next-14/src/sanity/fetch.ts
@@ -26,12 +26,10 @@ export async function sanityFetch<const QueryString extends string>({
     filterResponse: false,
     cacheMode: 'noStale',
     tag: 'fetch-sync-tags', // The request tag makes the fetch unique, avoids deduping with the cached query that has tags
-    cache: 'force-cache',
     next: {revalidate: 15 * 60},
   })
   const data = await client.fetch(query, params, {
     cacheMode: 'noStale',
-    cache: 'force-cache',
     next: {revalidate: 15 * 60, tags: syncTags},
   })
   return {data, tags: syncTags}

--- a/next-15/src/app/page.tsx
+++ b/next-15/src/app/page.tsx
@@ -2,8 +2,8 @@ import {sanityFetch} from '@/sanity/fetch'
 import {defineQuery} from 'groq'
 import type {Metadata} from 'next'
 import {Suspense} from 'react'
-import {TimeSince} from './TimeSince'
 import {Reactions, ReactionsFallback} from './Reactions'
+import {TimeSince} from './TimeSince'
 
 const DEMO_QUERY = defineQuery(
   `*[_type == "demo" && slug.current == $slug][0]{title,reactions[0..4]{_key,_ref},"fetchedAt": now()}`,

--- a/next-15/src/sanity/client.ts
+++ b/next-15/src/sanity/client.ts
@@ -3,6 +3,6 @@ import {createClient} from '@sanity/client'
 export const client = createClient({
   projectId: 'hiomol4a',
   dataset: 'lcapi',
-  apiVersion: '2025-02-19',
+  apiVersion: '2025-02-20',
   useCdn: true,
 })

--- a/next-15/src/sanity/fetch.ts
+++ b/next-15/src/sanity/fetch.ts
@@ -7,7 +7,12 @@ import {client} from './client'
  * The `defineLive` utility in `next-sanity` handles more advanced use cases, such as live preview, integrating with `sanity/presentation`, and more.
  * @example
  * import {createClient, defineLive} from 'next-sanity'
- * export const {sanityFetch, SanityLive} = defineLive({client: createClient({projectId, dataset, ...})})
+ * export const {sanityFetch, SanityLive} = defineLive({
+ *   client: createClient({projectId, dataset, ...}),
+ *   fetchOptions: {
+ *     revalidate: 15 * 60
+ *   }
+ * })
  */
 export async function sanityFetch<const QueryString extends string>({
   query,

--- a/next-15/src/sanity/fetch.ts
+++ b/next-15/src/sanity/fetch.ts
@@ -27,7 +27,7 @@ export async function sanityFetch<const QueryString extends string>({
   const data = await client.fetch(query, params, {
     cacheMode: 'noStale',
     cache: 'force-cache',
-    next: {tags: syncTags},
+    next: {revalidate: 15 * 60, tags: syncTags},
   })
   return {data, tags: syncTags}
 }

--- a/next-canary/src/sanity/fetch.ts
+++ b/next-canary/src/sanity/fetch.ts
@@ -1,5 +1,5 @@
 import {type ClientReturn, type QueryParams} from '@sanity/client'
-import {unstable_cacheLife as cacheLife, unstable_cacheTag as cacheTag} from 'next/cache'
+import {unstable_cacheTag as cacheTag} from 'next/cache'
 import {client} from './client'
 
 export async function sanityFetch<const QueryString extends string>({

--- a/next-canary/src/sanity/fetch.ts
+++ b/next-canary/src/sanity/fetch.ts
@@ -11,16 +11,6 @@ export async function sanityFetch<const QueryString extends string>({
 }): Promise<{data: ClientReturn<QueryString, unknown>; tags?: string[]}> {
   'use cache'
 
-  /**
-   * The default cache profile isn't ideal for live content, as it has unnecessary time based background validation, as well as a too lazy client stale value
-   * https://github.com/vercel/next.js/blob/8dd358002baf4244c0b2e38b5bda496daf60dacb/packages/next/cache.d.ts#L14-L26
-   */
-  cacheLife({
-    stale: Infinity,
-    revalidate: Infinity,
-    expire: Infinity,
-  })
-
   const {result, syncTags} = await client.fetch(query, params, {
     filterResponse: false,
     cacheMode: 'noStale',

--- a/next-enterprise/src/sanity/client.ts
+++ b/next-enterprise/src/sanity/client.ts
@@ -3,6 +3,6 @@ import {createClient} from '@sanity/client'
 export const client = createClient({
   projectId: 'hiomol4a',
   dataset: 'lcapi',
-  apiVersion: '2025-02-19',
+  apiVersion: '2025-02-20',
   useCdn: true,
 })

--- a/next-enterprise/src/sanity/fetch.ts
+++ b/next-enterprise/src/sanity/fetch.ts
@@ -7,7 +7,12 @@ import {client} from './client'
  * The `defineLive` utility in `next-sanity` handles more advanced use cases, such as live preview, integrating with `sanity/presentation`, and more.
  * @example
  * import {createClient, defineLive} from 'next-sanity'
- * export const {sanityFetch, SanityLive} = defineLive({client: createClient({projectId, dataset, ...})})
+ * export const {sanityFetch, SanityLive} = defineLive({
+ *   client: createClient({projectId, dataset, ...}),
+ *   fetchOptions: {
+ *     revalidate: process.env.VERCEL_ENV === 'preview' ? 15 * 60 : undefined
+ *   }
+ * })
  */
 export async function sanityFetch<const QueryString extends string>({
   query,

--- a/next-enterprise/src/sanity/fetch.ts
+++ b/next-enterprise/src/sanity/fetch.ts
@@ -30,13 +30,16 @@ export async function sanityFetch<const QueryString extends string>({
     cache: 'force-cache',
     // Since we're double-fetching, and this request doesn't have a cache tags, we set a time based revalidation to ensure there's
     // an eventual consistency guarantee for certain edge cases that wouldn't be caught be the expirator service
-    next: {revalidate}
+    next: {revalidate},
   })
   const data = await client.fetch(query, params, {
     cacheMode: 'noStale',
     cache: 'force-cache',
     // If we're not in production we can't expect the webhook to be able to expire tags, so we fallback to time based revalidation
-    next: {revalidate: process.env.VERCEL_ENV === 'preview' ? revalidate : undefined, tags: syncTags},
+    next: {
+      revalidate: process.env.VERCEL_ENV === 'preview' ? revalidate : undefined,
+      tags: syncTags,
+    },
   })
   return {data, tags: syncTags}
 }

--- a/next-enterprise/src/sanity/fetch.ts
+++ b/next-enterprise/src/sanity/fetch.ts
@@ -22,6 +22,9 @@ export async function sanityFetch<const QueryString extends string>({
     cacheMode: 'noStale',
     tag: 'fetch-sync-tags', // The request tag makes the fetch unique, avoids deduping with the cached query that has tags
     cache: 'force-cache',
+    // Since we're double-fetching, and this request doesn't have a cache tags, we set a time based revalidation to ensure there's
+    // an eventual consistency guarantee for certain edge cases that wouldn't be caught be the expirator service
+    next: {revalidate: 15 * 60, }
   })
   const data = await client.fetch(query, params, {
     cacheMode: 'noStale',


### PR DESCRIPTION
Updates all next demos, minus the `next-enterprise`, to use the same 15min default lifetime that `'use cache'` has. This ensures eventual consistency even if there are no observers on an app like `next-14`, `next-15` or `next-canary`.
The `next-enterprise` example uses a webhook service that uses the Live API to call an API handler that invalidates tags, thus ensuring eventual consistency with no observers, and the lowest possible API calls while still delivering a 2-5s of P99 latency, up to 10s with P75.